### PR TITLE
added query and sort field to create an incremental reindex

### DIFF
--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/ReindexAction.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/ReindexAction.java
@@ -12,7 +12,8 @@ public final class ReindexAction {
       ReindexInvoker.invokeReindexing(
           commandParser.getSourcePointer(),
           commandParser.getTargetPointer(),
-          commandParser.getSegmentation());
+          commandParser.getSegmentation(),
+          commandParser.getQuery());
     }
   }
 }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/ReindexCommandParser.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/ReindexCommandParser.java
@@ -4,16 +4,18 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.command.ReindexCommand;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
-import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ParsingElasticsearchAddressException;
-import pl.allegro.tech.search.elasticsearch.tools.reindex.query.QuerySegmentationFactory;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointerBuilder;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ParsingElasticsearchAddressException;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.query.QuerySegmentation;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.query.QuerySegmentationFactory;
 
 public class ReindexCommandParser {
 
   private ElasticDataPointer sourcePointer;
   private ElasticDataPointer targetPointer;
   private QuerySegmentation segmentation;
+  private ElasticSearchQuery query;
 
 
   public boolean tryParse(String... args) {
@@ -45,6 +47,7 @@ public class ReindexCommandParser {
         .setAddress(command.getTarget())
         .build();
     segmentation = getFieldSegmentation(command);
+    query = new ElasticSearchQuery.ElasticSearchQueryBuilder(command).build();
   }
 
   private QuerySegmentation getFieldSegmentation(ReindexCommand command) {
@@ -61,5 +64,9 @@ public class ReindexCommandParser {
 
   public QuerySegmentation getSegmentation() {
     return segmentation;
+  }
+
+  public ElasticSearchQuery getQuery() {
+    return query;
   }
 }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/command/ReindexCommand.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/command/ReindexCommand.java
@@ -22,6 +22,15 @@ public class ReindexCommand {
   @Parameter(names = { "-segmentationField" }, description = "Segmentation field")
   private String segmentationField;
 
+  @Parameter(names = { "-query" }, description = "Give a query to start from")
+  private String query;
+
+  @Parameter(names = { "-sort" }, description = "Give field to sort on")
+  private String sort;
+
+  @Parameter(names = { "-sortOrder" }, description = "Give sortOrder")
+  private String sortOrder;
+
   @Parameter(names = { "-segmentationThresholds" }, description = "Segmentation thresholds (only double type)")
   private List<Double> segmentationThresholds;
 
@@ -36,6 +45,18 @@ public class ReindexCommand {
   }
   public String getSegmentationField() {
     return segmentationField;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public String getSort() {
+    return sort;
+  }
+
+  public String getSortOrder() {
+    return sortOrder;
   }
 
   public List<Double> getSegmentationThresholds() {

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchQuery.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchQuery.java
@@ -1,0 +1,52 @@
+package pl.allegro.tech.search.elasticsearch.tools.reindex.connection;
+
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.command.ReindexCommand;
+
+/**
+ * Used when starting the reindex from a specific point.
+ */
+public class ElasticSearchQuery {
+  private final String query;
+  private final SortBuilder sort;
+
+  public ElasticSearchQuery(String query) {
+   this(query, null);
+  }
+
+  public ElasticSearchQuery(String query, SortBuilder sort) {
+    this.query = query;
+    this.sort = sort;
+  }
+
+  public String getQuery() {
+    return query;
+  }
+
+  public SortBuilder getSort() {
+    return sort;
+  }
+
+  public static class ElasticSearchQueryBuilder {
+    private String query;
+    private String sort;
+    private SortOrder sortOrder;
+    public ElasticSearchQueryBuilder(ReindexCommand reindexCommand) {
+      if (reindexCommand != null) {
+        this.query = reindexCommand.getQuery();
+        this.sort = reindexCommand.getSort();
+        try {
+          this.sortOrder = SortOrder.valueOf(reindexCommand.getSortOrder());
+        } catch (IllegalArgumentException | NullPointerException e) {
+          this.sortOrder = SortOrder.ASC;
+        }
+      }
+    }
+
+    public ElasticSearchQuery build() {
+      return new ElasticSearchQuery(query, new FieldSortBuilder(sort).order(sortOrder));
+    }
+  }
+}

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchQuery.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchQuery.java
@@ -46,7 +46,14 @@ public class ElasticSearchQuery {
     }
 
     public ElasticSearchQuery build() {
-      return new ElasticSearchQuery(query, new FieldSortBuilder(sort).order(sortOrder));
+      FieldSortBuilder fieldSortBuilder = null;
+      if (sort != null) {
+        if (sortOrder == null) {
+          sortOrder = SortOrder.ASC;
+        }
+        fieldSortBuilder = new FieldSortBuilder(sort).order(sortOrder);
+      }
+      return new ElasticSearchQuery(query, fieldSortBuilder);
     }
   }
 }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/QueryComponent.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/QueryComponent.java
@@ -1,13 +1,14 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.process;
 
-import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
-import pl.allegro.tech.search.elasticsearch.tools.reindex.query.BoundedSegment;
-import pl.allegro.tech.search.elasticsearch.tools.reindex.query.filter.BoundedFilterFactory;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.unit.TimeValue;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.query.BoundedSegment;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.query.filter.BoundedFilterFactory;
 
 import java.util.Optional;
 
@@ -21,13 +22,15 @@ public class QueryComponent {
   private Optional<String> segmentationField;
   private ElasticDataPointer dataPointer;
   private Optional<BoundedSegment> bound;
+  private ElasticSearchQuery query;
   private BoundedFilterFactory boundedFilterFactory = new BoundedFilterFactory();
 
-  QueryComponent(Client client, ElasticDataPointer dataPointer, Optional<String> segmentationField, Optional<BoundedSegment> bound) {
+  QueryComponent(Client client, ElasticDataPointer dataPointer, Optional<String> segmentationField, Optional<BoundedSegment> bound, ElasticSearchQuery query) {
     this.client = client;
     this.dataPointer = dataPointer;
     this.segmentationField = segmentationField;
     this.bound = bound;
+    this.query = query;
   }
 
   public SearchResponse prepareSearchScrollRequest() {
@@ -37,6 +40,13 @@ public class QueryComponent {
         .addFields("_ttl", "_source")
         .setScroll(new TimeValue(SCROLL_TIME_LIMIT))
         .setSize(SCROLL_SHARD_LIMIT);
+
+    if (query != null && query.getQuery() != null && !"".equals(query.getQuery())) {
+      searchRequestBuilder.setQuery(query.getQuery());
+    }
+    if (query != null && query.getSort() != null) {
+      searchRequestBuilder.addSort(query.getSort());
+    }
 
     bound.map(resolvedBound -> boundedFilterFactory.createBoundedFilter(segmentationField.get(), resolvedBound))
         .ifPresent(searchRequestBuilder::setQuery);

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/QueryComponentBuilder.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/QueryComponentBuilder.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.process;
 
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.query.BoundedSegment;
 import org.elasticsearch.client.Client;
 
@@ -11,6 +12,7 @@ public final class QueryComponentBuilder {
   private ElasticDataPointer dataPointer;
   private Optional<String> segmentationField = Optional.empty();
   private Optional<BoundedSegment> bound = Optional.empty();
+  private ElasticSearchQuery query;
 
   private QueryComponentBuilder() {
   }
@@ -35,11 +37,18 @@ public final class QueryComponentBuilder {
     return this;
   }
 
+  public QueryComponentBuilder setQuery(ElasticSearchQuery query) {
+    this.query = query;
+    return this;
+  }
+
+
   public static QueryComponentBuilder builder() {
     return new QueryComponentBuilder();
   }
 
   public QueryComponent createQueryComponent() {
-    return new QueryComponent(client, dataPointer, segmentationField, bound);
+    return new QueryComponent(client, dataPointer, segmentationField, bound, query);
   }
+
 }

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/ReindexInvokerTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/ReindexInvokerTest.java
@@ -2,11 +2,13 @@ package pl.allegro.tech.search.elasticsearch.tools.reindex;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.embeded.EmbeddedElasticsearchCluster;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.embeded.IndexDocument;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.query.DoubleFieldSegmentation;
@@ -52,8 +54,9 @@ public class ReindexInvokerTest {
     embeddedElasticsearchCluster.recreateIndex(SOURCE_INDEX);
     ElasticDataPointer sourceDataPointer = embeddedElasticsearchCluster.createDataPointer(SOURCE_INDEX);
     ElasticDataPointer targetDataPointer = embeddedElasticsearchCluster.createDataPointer(TARGET_INDEX);
+    ElasticSearchQuery elasticSearchQuery = embeddedElasticsearchCluster.createInitialQuery("");
     //when
-    ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer, EmptySegmentation.createEmptySegmentation());
+    ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer, EmptySegmentation.createEmptySegmentation(), elasticSearchQuery);
     //then
     assertFalse(embeddedElasticsearchCluster.indexExist(TARGET_INDEX));
   }
@@ -64,9 +67,10 @@ public class ReindexInvokerTest {
     embeddedElasticsearchCluster.recreateIndex(SOURCE_INDEX);
     ElasticDataPointer sourceDataPointer = embeddedElasticsearchCluster.createDataPointer(SOURCE_INDEX);
     ElasticDataPointer targetDataPointer = embeddedElasticsearchCluster.createDataPointer(TARGET_INDEX);
+    ElasticSearchQuery elasticSearchQuery = embeddedElasticsearchCluster.createInitialQuery("");
     //when
     ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer, DoubleFieldSegmentation.create("fieldName",
-        Lists.newArrayList(1.0, 3.0)));
+        Lists.newArrayList(1.0, 3.0)), elasticSearchQuery);
     //then
     assertFalse(embeddedElasticsearchCluster.indexExist(TARGET_INDEX));
   }
@@ -77,8 +81,10 @@ public class ReindexInvokerTest {
     indexWithSampleData();
     ElasticDataPointer sourceDataPointer = embeddedElasticsearchCluster.createDataPointer(SOURCE_INDEX);
     ElasticDataPointer targetDataPointer = embeddedElasticsearchCluster.createDataPointer(TARGET_INDEX);
+    ElasticSearchQuery elasticSearchQuery = embeddedElasticsearchCluster.createInitialQuery("");
     //when
-    ReindexingSummary reindexingSummary = ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer, EmptySegmentation.createEmptySegmentation());
+    ReindexingSummary reindexingSummary = ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer,
+        EmptySegmentation.createEmptySegmentation(), elasticSearchQuery);
     //then
     assertEquals(9L, embeddedElasticsearchCluster.count(TARGET_INDEX));
     assertThat(reindexingSummary)
@@ -94,9 +100,10 @@ public class ReindexInvokerTest {
     indexWithSampleData();
     ElasticDataPointer sourceDataPointer = embeddedElasticsearchCluster.createDataPointer(SOURCE_INDEX);
     ElasticDataPointer targetDataPointer = embeddedElasticsearchCluster.createDataPointer(TARGET_INDEX);
+    ElasticSearchQuery elasticSearchQuery = embeddedElasticsearchCluster.createInitialQuery("");
     //when
     ReindexingSummary reindexingSummary = ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer, DoubleFieldSegmentation.create("fieldName",
-        Lists.newArrayList(1.0, 3.0, 7.0)));
+        Lists.newArrayList(1.0, 3.0, 7.0)), elasticSearchQuery);
     //then
     assertEquals(6L, embeddedElasticsearchCluster.count(TARGET_INDEX));
     assertThat(reindexingSummary)
@@ -111,14 +118,35 @@ public class ReindexInvokerTest {
     indexWithSampleData();
     ElasticDataPointer sourceDataPointer = embeddedElasticsearchCluster.createDataPointer(SOURCE_INDEX);
     ElasticDataPointer targetDataPointer = embeddedElasticsearchCluster.createDataPointer(TARGET_INDEX);
+    ElasticSearchQuery elasticSearchQuery = embeddedElasticsearchCluster.createInitialQuery("");
     //when
     ReindexingSummary reindexingSummary = ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer, StringPrefixSegmentation.create("fieldName",
-        Lists.newArrayList("1", "2", "3", "4")));
+        Lists.newArrayList("1", "2", "3", "4")), elasticSearchQuery);
     //then
     assertEquals(4L, embeddedElasticsearchCluster.count(TARGET_INDEX));
     assertThat(reindexingSummary)
         .hasIndexedCount(4L)
         .hasQueriedCount(4L)
+        .hasFailedIndexedCount(0L);
+  }
+
+
+  @Test
+  public void indexingWithStartQuery() throws Exception {
+    //given
+    indexWithSampleData();
+    ElasticDataPointer sourceDataPointer = embeddedElasticsearchCluster.createDataPointer(SOURCE_INDEX);
+    ElasticDataPointer targetDataPointer = embeddedElasticsearchCluster.createDataPointer(TARGET_INDEX);
+    ElasticSearchQuery elasticSearchQuery = embeddedElasticsearchCluster.createInitialQuery("" +
+        "{\"range\": {\"fieldName\" : { \"gte\" : \"5\"}}}", new FieldSortBuilder("fieldName"));
+    //when
+    ReindexingSummary reindexingSummary = ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer,
+        EmptySegmentation.createEmptySegmentation(), elasticSearchQuery);
+    //then
+    assertEquals(5L, embeddedElasticsearchCluster.count(TARGET_INDEX));
+    assertThat(reindexingSummary)
+        .hasIndexedCount(5L)
+        .hasQueriedCount(5L)
         .hasFailedIndexedCount(0L);
   }
 
@@ -137,8 +165,9 @@ public class ReindexInvokerTest {
     embeddedElasticsearchCluster.deleteIndex(SOURCE_INDEX);
     ElasticDataPointer sourceDataPointer = embeddedElasticsearchCluster.createDataPointer(SOURCE_INDEX);
     ElasticDataPointer targetDataPointer = embeddedElasticsearchCluster.createDataPointer(TARGET_INDEX);
+    ElasticSearchQuery elasticSearchQuery = embeddedElasticsearchCluster.createInitialQuery("");
     //when
-    ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer, EmptySegmentation.createEmptySegmentation());
+    ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer, EmptySegmentation.createEmptySegmentation(), elasticSearchQuery);
     //then
     assertFalse(embeddedElasticsearchCluster.indexExist(TARGET_INDEX));
 

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/ReindexInvokerWithIndexingErrorsTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/ReindexInvokerWithIndexingErrorsTest.java
@@ -8,6 +8,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.embeded.EmbeddedElasticsearchCluster;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.embeded.IndexDocument;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.query.EmptySegmentation;
@@ -46,8 +47,9 @@ public class ReindexInvokerWithIndexingErrorsTest {
     embeddedElasticsearchCluster.createIndex(TARGET_INDEX, DATA_TYPE, createStrictMappingDefinition());
     ElasticDataPointer sourceDataPointer = embeddedElasticsearchCluster.createDataPointer(SOURCE_INDEX);
     ElasticDataPointer targetDataPointer = embeddedElasticsearchCluster.createDataPointer(TARGET_INDEX);
+    ElasticSearchQuery elasticSearchQuery = embeddedElasticsearchCluster.createInitialQuery("");
     //when
-    ReindexingSummary reindexingSummary = ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer, EmptySegmentation.createEmptySegmentation());
+    ReindexingSummary reindexingSummary = ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer, EmptySegmentation.createEmptySegmentation(), elasticSearchQuery);
     //then
     Assertions.assertThat(embeddedElasticsearchCluster.count(SOURCE_INDEX)).isEqualTo(8L);
     Assertions.assertThat(embeddedElasticsearchCluster.count(TARGET_INDEX)).isEqualTo(4L);
@@ -66,6 +68,7 @@ public class ReindexInvokerWithIndexingErrorsTest {
         Stream.concat(docsWithField1, docsWithField2));
   }
 
+  @SuppressWarnings("unchecked")
   private Stream<IndexDocument> createDocsStream(int amount, IntFunction docMapper) {
     return IntStream.range(1, amount)
         .mapToObj(docMapper);

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/TTLTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/TTLTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.embeded.EmbeddedElasticsearchCluster;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.embeded.IndexDocument;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.query.EmptySegmentation;
@@ -52,12 +53,13 @@ public class TTLTest {
     //given
     embeddedElasticsearchCluster.createIndex(SOURCE_INDEX, DATA_TYPE, mappingWithTTL());
     embeddedElasticsearchCluster.createIndex(TARGET_INDEX, DATA_TYPE, mappingWithTTL());
+    ElasticSearchQuery elasticSearchQuery = embeddedElasticsearchCluster.createInitialQuery("");
     indexSampleDataWithTTL();
     ElasticDataPointer sourceDataPointer = embeddedElasticsearchCluster.createDataPointer(SOURCE_INDEX);
     ElasticDataPointer targetDataPointer = embeddedElasticsearchCluster.createDataPointer(TARGET_INDEX);
 
     //when
-    ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer, EmptySegmentation.createEmptySegmentation());
+    ReindexInvoker.invokeReindexing(sourceDataPointer, targetDataPointer, EmptySegmentation.createEmptySegmentation(), elasticSearchQuery);
     SearchResponse targetResponse = embeddedElasticsearchCluster.client().prepareSearch(TARGET_INDEX).addFields("_ttl").get();
 
     //then

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/embeded/EmbeddedElasticsearchCluster.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/embeded/EmbeddedElasticsearchCluster.java
@@ -7,9 +7,11 @@ import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeBuilder;
+import org.elasticsearch.search.sort.SortBuilder;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.ReindexInvokerTest;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointerBuilder;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
 
 import java.util.stream.Stream;
 
@@ -80,11 +82,10 @@ public final class EmbeddedElasticsearchCluster {
   }
 
   public ElasticDataPointer createDataPointer(String indexName) {
-    ElasticDataPointer dataPointer = ElasticDataPointerBuilder.builder()
+    return ElasticDataPointerBuilder.builder()
         .setAddress("http://127.0.0.1:" + ELS_TCP_PORT + "/" + indexName + "/" + ReindexInvokerTest.DATA_TYPE)
         .setClusterName(CLUSTER_NAME)
         .build();
-    return dataPointer;
   }
 
   public void indexWithSampleData(String sourceIndex, String type, Stream<IndexDocument> indexDocumentStream) {
@@ -106,4 +107,11 @@ public final class EmbeddedElasticsearchCluster {
         .get();
   }
 
+  public ElasticSearchQuery createInitialQuery(String query) {
+    return new ElasticSearchQuery(query);
+  }
+
+  public ElasticSearchQuery createInitialQuery(String query, SortBuilder sortOrder) {
+    return new ElasticSearchQuery(query, sortOrder);
+  }
 }


### PR DESCRIPTION
This change has been made to be able to create incremental re-indexes. 

Usecase: given a very large dataset with very frequent updates where a mapping has to be changed.
This can be handled incremental by locating a sortable field (e.g. _timestamp) and perform the incremental update a number of times where the timestamp field is used. E.g.
First run: no parameters
Second run: check the max _timestamp in the target index and add this as query and sort fields:
- query "\"{range\": {\"_timestamp\" : {\"gte\" : 1447142880000}}}\""
  -sort _timestamp
