### PR TITLE
Update to Elasticsearch 2 0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.elasticsearch', name: 'elasticsearch', version: '1.3.2'
+    compile group: 'org.elasticsearch', name: 'elasticsearch', version: '2.0.0'
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.7'
     compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.0.13'
     compile group: 'com.beust', name: 'jcommander', version: '1.30'

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchClientFactory.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchClientFactory.java
@@ -1,9 +1,10 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.connection;
 
+import java.net.InetSocketAddress;
+
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.cluster.ClusterName;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 
@@ -13,13 +14,13 @@ public final class ElasticSearchClientFactory {
   }
 
   public static Client createClient(ElasticDataPointer elasticDataPointer) {
-    Settings settings = ImmutableSettings.settingsBuilder()
+    Settings settings = Settings.settingsBuilder()
         .put("client.transport.sniff", true)
         .put(ClusterName.SETTING, elasticDataPointer.getClusterName())
         .build();
-    TransportClient client = new TransportClient(settings);
-    client.addTransportAddress(new InetSocketTransportAddress(elasticDataPointer.getHost(), elasticDataPointer
-        .getPort()));
+    TransportClient client = TransportClient.builder().settings(settings).build();
+    client.addTransportAddress(new InetSocketTransportAddress(new InetSocketAddress(elasticDataPointer.getHost(), elasticDataPointer
+        .getPort())));
     return client;
   }
 }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/DoubleFieldSegmentation.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/DoubleFieldSegmentation.java
@@ -1,7 +1,5 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.query;
 
-import org.elasticsearch.common.collect.Lists;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/filter/BoundedFilterCreationStrategy.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/filter/BoundedFilterCreationStrategy.java
@@ -1,10 +1,9 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.query.filter;
 
-import pl.allegro.tech.search.elasticsearch.tools.reindex.query.BoundedSegment;
-import org.elasticsearch.index.query.BaseQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 
 public interface BoundedFilterCreationStrategy<SegmentType> {
 
-  BaseQueryBuilder create(String fieldName, SegmentType resolvedBound);
+	QueryBuilder create(String fieldName, SegmentType resolvedBound);
 
 }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/filter/BoundedFilterFactory.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/filter/BoundedFilterFactory.java
@@ -1,13 +1,12 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.query.filter;
 
+import org.elasticsearch.index.query.QueryBuilder;
+
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import org.elasticsearch.index.query.BaseQueryBuilder;
+
 import pl.allegro.tech.search.elasticsearch.tools.reindex.query.BoundedSegment;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.query.PrefixSegment;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.query.RangeSegment;
-
-import java.util.List;
 
 public class BoundedFilterFactory {
 
@@ -17,7 +16,7 @@ public class BoundedFilterFactory {
           .put(RangeSegment.class, new RangeFilterCreationStrategy())
           .build();
 
-  public BaseQueryBuilder createBoundedFilter(String fieldName, BoundedSegment boundedSegment) {
+  public QueryBuilder createBoundedFilter(String fieldName, BoundedSegment boundedSegment) {
     return strategy.get(boundedSegment.getClass()).create(fieldName, boundedSegment);
   }
 

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/filter/PrefixFilterCreationStrategy.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/filter/PrefixFilterCreationStrategy.java
@@ -1,13 +1,13 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.query.filter;
 
-import pl.allegro.tech.search.elasticsearch.tools.reindex.query.BoundedSegment;
-import pl.allegro.tech.search.elasticsearch.tools.reindex.query.PrefixSegment;
-import org.elasticsearch.index.query.BaseQueryBuilder;
 import org.elasticsearch.index.query.PrefixQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+
+import pl.allegro.tech.search.elasticsearch.tools.reindex.query.PrefixSegment;
 
 public class PrefixFilterCreationStrategy implements BoundedFilterCreationStrategy<PrefixSegment> {
   @Override
-  public BaseQueryBuilder create(String fieldName, PrefixSegment resolvedBound) {
+  public QueryBuilder create(String fieldName, PrefixSegment resolvedBound) {
     return new PrefixQueryBuilder(fieldName, resolvedBound.getPrefix());
   }
 

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/filter/RangeFilterCreationStrategy.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/filter/RangeFilterCreationStrategy.java
@@ -1,13 +1,13 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.query.filter;
 
-import pl.allegro.tech.search.elasticsearch.tools.reindex.query.BoundedSegment;
-import pl.allegro.tech.search.elasticsearch.tools.reindex.query.RangeSegment;
-import org.elasticsearch.index.query.BaseQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
+
+import pl.allegro.tech.search.elasticsearch.tools.reindex.query.RangeSegment;
 
 public class RangeFilterCreationStrategy implements BoundedFilterCreationStrategy<RangeSegment> {
   @Override
-  public BaseQueryBuilder create(String fieldName, RangeSegment resolvedBound) {
+  public QueryBuilder create(String fieldName, RangeSegment resolvedBound) {
     return new RangeQueryBuilder(fieldName)
         .lte(resolvedBound.getUpperBound())
         .gt(resolvedBound.getLowerOpenBound());

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchClientProducerTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchClientProducerTest.java
@@ -1,14 +1,14 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.connection;
 
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+
 import org.assertj.core.api.Assertions;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
-import static org.junit.Assert.assertEquals;
 
 public class ElasticSearchClientProducerTest {
 
@@ -18,7 +18,12 @@ public class ElasticSearchClientProducerTest {
 
   @Before
   public void setUp() throws Exception {
-    dataNode = nodeBuilder().clusterName(CLUSTER_NAME).node();
+    Settings.Builder settings = nodeBuilder().settings()
+    		.put("path.home", ".");
+
+    dataNode = nodeBuilder().
+    		settings(settings).
+    		clusterName(CLUSTER_NAME).node();
   }
 
   @After

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/embeded/EmbeddedElasticsearchCluster.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/embeded/EmbeddedElasticsearchCluster.java
@@ -30,7 +30,8 @@ public final class EmbeddedElasticsearchCluster {
         .data(true);
     Settings.Builder settings = nodeBuilder.settings()
         .put("http.port", ELS_PORT)
-        .put("index.store.type", "memory")
+        //.put("index.store.type", "memory")
+        .put("path.home", ".")
         .put("transport.tcp.port", apiPort);
 
     dataNode = nodeBuilder.settings(settings).node();

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/embeded/EmbeddedElasticsearchCluster.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/embeded/EmbeddedElasticsearchCluster.java
@@ -1,19 +1,20 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.embeded;
 
-import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.IndicesAdminClient;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.node.Node;
-import org.elasticsearch.node.NodeBuilder;
-import pl.allegro.tech.search.elasticsearch.tools.reindex.ReindexInvokerTest;
-import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
-import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointerBuilder;
+import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
 
 import java.util.stream.Stream;
 
-import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.node.NodeBuilder;
+
+import pl.allegro.tech.search.elasticsearch.tools.reindex.ReindexInvokerTest;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointerBuilder;
 
 public final class EmbeddedElasticsearchCluster {
 
@@ -27,7 +28,7 @@ public final class EmbeddedElasticsearchCluster {
     NodeBuilder nodeBuilder = nodeBuilder()
         .clusterName(clusterName)
         .data(true);
-    ImmutableSettings.Builder settings = nodeBuilder.settings()
+    Settings.Builder settings = nodeBuilder.settings()
         .put("http.port", ELS_PORT)
         .put("index.store.type", "memory")
         .put("transport.tcp.port", apiPort);

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/filter/BoundedFilterFactoryTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/filter/BoundedFilterFactoryTest.java
@@ -1,13 +1,14 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.query.filter;
 
-import pl.allegro.tech.search.elasticsearch.tools.reindex.query.PrefixSegment;
-import pl.allegro.tech.search.elasticsearch.tools.reindex.query.RangeSegment;
-import org.elasticsearch.index.query.BaseQueryBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.elasticsearch.index.query.PrefixQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.query.PrefixSegment;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.query.RangeSegment;
 
 public class BoundedFilterFactoryTest {
 
@@ -17,7 +18,7 @@ public class BoundedFilterFactoryTest {
     BoundedFilterFactory factory = new BoundedFilterFactory();
     PrefixSegment anyPrefixSegment = new PrefixSegment("prefix");
     //when
-    BaseQueryBuilder filter = factory.createBoundedFilter("fieldName", anyPrefixSegment);
+    QueryBuilder filter = factory.createBoundedFilter("fieldName", anyPrefixSegment);
     //then
     assertThat(filter).isInstanceOf(PrefixQueryBuilder.class);
   }
@@ -28,7 +29,7 @@ public class BoundedFilterFactoryTest {
     BoundedFilterFactory factory = new BoundedFilterFactory();
     RangeSegment anyRangeSegment = new RangeSegment(1.0, 2.0);
     //when
-    BaseQueryBuilder filter = factory.createBoundedFilter("fieldName", anyRangeSegment);
+    QueryBuilder filter = factory.createBoundedFilter("fieldName", anyRangeSegment);
     //then
     assertThat(filter).isInstanceOf(RangeQueryBuilder.class);
   }


### PR DESCRIPTION
This PR provides the necessary code and test changes to run against Elasticsearch 2.0. 

Backwards compatibility is unfortunately not possible due to the major changes in the Elasticsearch APIs.
