### PR TITLE
Add a commandline parameter to disable cluster sniffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Options:
        Target f.e. http://localhost:9300/target_index/type
     -tc, target-cluster
        Target cluster name
+    -disable-cluster-sniffing
+       Don't try to determine additional cluster nodes (e.g. when your network
+       only allows access to one of the nodes)
+       Default: false
     -segmentationField
        Segmentation field
     -segmentationPrefixes
@@ -87,6 +91,10 @@ Options:
 
 `segmentationField`, `segmentationThreshold` and `segmentationPrefixes` are optional parameters, allowing to spread
 querying for field with double values or prefix for string field
+
+`disable-cluster-sniffing` allows to work in cases where the network-setup makes it impossible to connect to all nodes
+of the source or target cluster. Note that it may lead to slightly reduced reindexing rates as data can only be sent
+via one node then.
 
 During reindex process progress message is prompted after each scroll query.
 

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/ReindexCommandParser.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/ReindexCommandParser.java
@@ -2,12 +2,13 @@ package pl.allegro.tech.search.elasticsearch.tools.reindex;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
+
 import pl.allegro.tech.search.elasticsearch.tools.reindex.command.ReindexCommand;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
-import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ParsingElasticsearchAddressException;
-import pl.allegro.tech.search.elasticsearch.tools.reindex.query.QuerySegmentationFactory;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointerBuilder;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ParsingElasticsearchAddressException;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.query.QuerySegmentation;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.query.QuerySegmentationFactory;
 
 public class ReindexCommandParser {
 
@@ -39,10 +40,12 @@ public class ReindexCommandParser {
     sourcePointer = ElasticDataPointerBuilder.builder()
         .setClusterName(command.getSourceClusterName())
         .setAddress(command.getSource())
+        .setSniff(!command.isDisableSniff())
         .build();
     targetPointer = ElasticDataPointerBuilder.builder()
         .setClusterName(command.getTargetClusterName())
         .setAddress(command.getTarget())
+        .setSniff(!command.isDisableSniff())
         .build();
     segmentation = getFieldSegmentation(command);
   }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/command/ReindexCommand.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/command/ReindexCommand.java
@@ -1,8 +1,8 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.command;
 
-import com.beust.jcommander.Parameter;
-
 import java.util.List;
+
+import com.beust.jcommander.Parameter;
 
 public class ReindexCommand {
 
@@ -28,6 +28,9 @@ public class ReindexCommand {
   @Parameter(names = { "-segmentationPrefixes" }, description = "Segmentation prefixes (comma-separated)")
   private List<String> segmentationPrefixes;
 
+  @Parameter(names = { "-disable-cluster-sniffing" }, description = "Don't try to determine additional cluster nodes (e.g. when your network only allows access to one of the nodes)")
+  private boolean disableSniff;
+
   public String getSourceClusterName() {
     return sourceClusterName;
   }
@@ -52,5 +55,9 @@ public class ReindexCommand {
 
   public String getTarget() {
     return target;
+  }
+
+  public boolean isDisableSniff() {
+    return disableSniff;
   }
 }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticDataPointer.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticDataPointer.java
@@ -7,13 +7,15 @@ public class ElasticDataPointer {
   private final String indexName;
   private final String typeName;
   private final int port;
+  private final boolean sniff;
 
-  ElasticDataPointer(String host, String clusterName, String indexName, String typeName, int port) {
+  ElasticDataPointer(String host, String clusterName, String indexName, String typeName, int port, boolean sniff) {
     this.host = host;
     this.clusterName = clusterName;
     this.indexName = indexName;
     this.typeName = typeName;
     this.port = port;
+    this.sniff = sniff;
   }
 
   public String getHost() {
@@ -34,5 +36,9 @@ public class ElasticDataPointer {
 
   public int getPort() {
     return port;
+  }
+
+  public boolean isSniff() {
+    return sniff;
   }
 }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticDataPointerBuilder.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticDataPointerBuilder.java
@@ -6,6 +6,7 @@ public class ElasticDataPointerBuilder {
 
   private String clusterName = "elasticsearch";
   private ElasticAddress address;
+  private boolean sniff = true;
 
   private ElasticDataPointerBuilder() {
   }
@@ -20,9 +21,14 @@ public class ElasticDataPointerBuilder {
     return this;
   }
 
+  public ElasticDataPointerBuilder setSniff(boolean sniff) {
+    this.sniff = sniff;
+    return this;
+  }
+
   public ElasticDataPointer build() {
     return new ElasticDataPointer(address.getHost(), clusterName, address.getIndexName(), address.getTypeName(),
-        address.getPort());
+        address.getPort(), sniff);
   }
 
   public static ElasticDataPointerBuilder builder() {

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchClientFactory.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchClientFactory.java
@@ -15,7 +15,7 @@ public final class ElasticSearchClientFactory {
 
   public static Client createClient(ElasticDataPointer elasticDataPointer) {
     Settings settings = Settings.settingsBuilder()
-        .put("client.transport.sniff", true)
+        .put("client.transport.sniff", elasticDataPointer.isSniff())
         .put(ClusterName.SETTING, elasticDataPointer.getClusterName())
         .build();
     TransportClient client = TransportClient.builder().settings(settings).build();

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchClientProducerTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchClientProducerTest.java
@@ -45,4 +45,19 @@ public class ElasticSearchClientProducerTest {
     client.close();
   }
 
+
+  @Test
+  public void validateCreatedLocalElasticClientWithoutSniff() throws Exception {
+    //given
+    ElasticDataPointer dataPointer = ElasticDataPointerBuilder.builder()
+        .setAddress("http://localhost:9300/"+INDEX_NAME+"/type")
+        .setClusterName(CLUSTER_NAME)
+        .setSniff(false)
+        .build();
+    //when
+    Client client = ElasticSearchClientFactory.createClient(dataPointer);
+    //then
+    Assertions.assertThat(client.settings().get("cluster.name")).isEqualTo(CLUSTER_NAME);
+    client.close();
+  }
 }


### PR DESCRIPTION
 This is useful in setups where only some nodes are accessible, e.g. due to network/vpn-setup
