### PR TITLE
Keep _routing fields if they are set in the source index

### DIFF
--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/IndexingComponent.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/IndexingComponent.java
@@ -36,6 +36,9 @@ public class IndexingComponent {
       if (hit.getFields().get("_ttl") != null) {
         requestBuilder.setTTL(hit.getFields().get("_ttl").value());
       }
+      if (hit.getFields().get("_routing") != null) {
+        requestBuilder.setRouting(hit.getFields().get("_routing").value());
+      }
       requestBuilder.setSource(source);
       bulkRequest.add(requestBuilder);
     }


### PR DESCRIPTION
To use the same custom routing if one is used in the source-index, no behavior change if default routing is in place.
