### PR TITLE
Added support for segmentation by index shards

### DIFF
--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/command/ReindexCommand.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/command/ReindexCommand.java
@@ -2,12 +2,13 @@ package pl.allegro.tech.search.elasticsearch.tools.reindex.command;
 
 import com.beust.jcommander.Parameter;
 
+import java.util.Collections;
 import java.util.List;
 
 public class ReindexCommand {
 
   @Parameter(names = { "-s", "source" }, description = "Source f.e. http://localhost:9300/source_index/type",
-      required = true)
+          required = true)
   private String source;
 
   @Parameter(names = { "-sc", "source-cluster" }, description = "Source cluster name", required = true)
@@ -16,7 +17,7 @@ public class ReindexCommand {
   @Parameter(names = { "-tc", "target-cluster" }, description = "Target cluster name", required = true)
   private String targetClusterName;
   @Parameter(names = { "-t", "target" }, description = "Target f.e. http://localhost:9300/target_index/type",
-      required = true)
+          required = true)
   private String target;
 
   @Parameter(names = { "-segmentationField" }, description = "Segmentation field")
@@ -24,6 +25,9 @@ public class ReindexCommand {
 
   @Parameter(names = { "-query" }, description = "Give a query to filter data")
   private String query;
+
+  @Parameter(names = { "-shards" }, description = "Select the shards that will accept the query")
+  private List<Integer> shards = Collections.emptyList();
 
   @Parameter(names = { "-sort" }, description = "Give field to sort on (if query option in use)")
   private String sort;
@@ -37,6 +41,9 @@ public class ReindexCommand {
   @Parameter(names = { "-segmentationPrefixes" }, description = "Segmentation prefixes (comma-separated)")
   private List<String> segmentationPrefixes;
 
+  @Parameter(names = { "-segmentationByShards" }, description = "Segmentation by shards (true/false)")
+  private boolean segmentationByShards = false;
+
   public String getSourceClusterName() {
     return sourceClusterName;
   }
@@ -49,6 +56,10 @@ public class ReindexCommand {
 
   public String getQuery() {
     return query;
+  }
+
+  public List<Integer> getShards() {
+    return this.shards;
   }
 
   public String getSort() {
@@ -66,6 +77,8 @@ public class ReindexCommand {
   public List<String> getSegmentationPrefixes() {
     return segmentationPrefixes;
   }
+
+  public boolean getSegmentationByShards() { return segmentationByShards; }
 
   public String getSource() {
     return source;

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchQuery.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchQuery.java
@@ -1,16 +1,24 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.connection;
 
+import org.apache.commons.collections4.ArrayStack;
 import org.elasticsearch.search.sort.SortOrder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.StreamSupport;
 
 public class ElasticSearchQuery {
   private final String query;
   private final String sortField;
   private final SortOrder sortOrder;
+  private final List<Integer> shards;
 
-  ElasticSearchQuery(String query, String sortField, SortOrder sortOrder) {
+  ElasticSearchQuery(String query, String sortField, SortOrder sortOrder, List<Integer> shards) {
     this.query = query;
     this.sortField = sortField;
     this.sortOrder = sortOrder;
+    this.shards = Collections.unmodifiableList(shards);
   }
 
   public String getQuery() {
@@ -23,5 +31,13 @@ public class ElasticSearchQuery {
 
   public String getSortField() {
     return sortField;
+  }
+
+  public List<Integer> getShards() {
+    return this.shards;
+  }
+
+  public ElasticSearchQuery withShards(List<Integer> shards) {
+    return new ElasticSearchQuery(query, sortField, sortOrder, Collections.unmodifiableList(shards));
   }
 }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchQueryBuilder.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/connection/ElasticSearchQueryBuilder.java
@@ -3,10 +3,14 @@ package pl.allegro.tech.search.elasticsearch.tools.reindex.connection;
 import com.google.common.base.Strings;
 import org.elasticsearch.search.sort.SortOrder;
 
+import java.util.Collections;
+import java.util.List;
+
 public class ElasticSearchQueryBuilder {
   private String query;
   private String sortField;
   private SortOrder sortOrder = SortOrder.ASC;
+  private List<Integer> shards = Collections.emptyList();
 
 
   private ElasticSearchQueryBuilder() {
@@ -33,8 +37,17 @@ public class ElasticSearchQueryBuilder {
     return this;
   }
 
+  public ElasticSearchQueryBuilder setShards(List<Integer> shards) {
+    if (shards == null) {
+      this.shards = Collections.emptyList();
+    } else {
+      this.shards = shards;
+    }
+    return this;
+  }
+
   public ElasticSearchQuery build() {
-    return new ElasticSearchQuery(query, sortField, sortOrder);
+    return new ElasticSearchQuery(query, sortField, sortOrder, shards);
   }
 
   public static ElasticSearchQueryBuilder builder() {

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/IndexingComponent.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/IndexingComponent.java
@@ -32,12 +32,12 @@ public class IndexingComponent {
     for (SearchHit hit : hits) {
       Map<String, Object> source = hit.getSource();
       IndexRequestBuilder requestBuilder = prepareIndex(targetDataPointer.getIndexName(), targetDataPointer
-          .getTypeName(), hit.getId());
+              .getTypeName(), hit.getId());
       if (hit.getFields().get("_ttl") != null) {
-        requestBuilder.setTTL(hit.getFields().get("_ttl").value());
+        requestBuilder.setTTL(hit.getFields().get("_ttl").<Long>value());
       }
       if (hit.getFields().get("_routing") != null) {
-        requestBuilder.setRouting(hit.getFields().get("_routing").value());
+        requestBuilder.setRouting(hit.getFields().get("_routing").<String>value());
       }
       requestBuilder.setSource(source);
       bulkRequest.add(requestBuilder);
@@ -49,9 +49,9 @@ public class IndexingComponent {
     if (bulkRequest.numberOfActions() > 0) {
       BulkResponse bulkItemResponses = bulkRequest.execute().actionGet();
       Set<String> failedIds = Stream.of(bulkItemResponses.getItems())
-          .filter(BulkItemResponse::isFailed)
-          .map(BulkItemResponse::getId)
-          .collect(Collectors.toSet());
+              .filter(BulkItemResponse::isFailed)
+              .map(BulkItemResponse::getId)
+              .collect(Collectors.toSet());
       return Optional.of(new BulkResult(indexedCount, failedIds));
     }
     return Optional.empty();

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/QueryComponentBuilder.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/QueryComponentBuilder.java
@@ -5,6 +5,8 @@ import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSear
 import pl.allegro.tech.search.elasticsearch.tools.reindex.query.BoundedSegment;
 import org.elasticsearch.client.Client;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 public final class QueryComponentBuilder {
@@ -41,7 +43,6 @@ public final class QueryComponentBuilder {
     this.query = query;
     return this;
   }
-
 
   public static QueryComponentBuilder builder() {
     return new QueryComponentBuilder();

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/DoubleFieldSegmentation.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/DoubleFieldSegmentation.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.search.elasticsearch.tools.reindex.query;
 
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -12,8 +13,8 @@ public final class DoubleFieldSegmentation extends SegmentationQueryTrait implem
 
   private final Optional<String> fieldName;
 
-  private DoubleFieldSegmentation(String fieldName, List<Double> thresholds, ElasticSearchQuery query) {
-    super(query);
+  private DoubleFieldSegmentation(String fieldName, List<Double> thresholds, ElasticSearchQuery query, Boolean segmentationByShards) {
+    super(query, segmentationByShards);
     this.fieldName = Optional.of(fieldName);
     this.thresholds = Collections.unmodifiableList(thresholds);
   }
@@ -25,20 +26,39 @@ public final class DoubleFieldSegmentation extends SegmentationQueryTrait implem
 
   @Override
   public int getSegmentsCount() {
+    if (this.getSegmentationByShards() && this.getQuery().getShards().size() > 1) {
+      return (thresholds.size() - 1) * this.getQuery().getShards().size();
+    }
+
     return thresholds.size() - 1;
   }
 
   @Override
   public Optional<BoundedSegment> getThreshold(int i) {
+    int thresholdIndex = i;
+    if (getSegmentationByShards() && this.getQuery().getShards().size() > 1) {
+      thresholdIndex = i % (thresholds.size() - 1);
+    }
+
     RangeSegment segmentation =
-        RangeSegmentBuilder.builder()
-            .setLowerOpenBound(thresholds.get(i))
-            .setUpperBound(thresholds.get(i + 1))
-            .createRangeSegment();
+            RangeSegmentBuilder.builder()
+                    .setLowerOpenBound(thresholds.get(thresholdIndex))
+                    .setUpperBound(thresholds.get(thresholdIndex + 1))
+                    .createRangeSegment();
+
     return Optional.of(segmentation);
   }
 
-  public static DoubleFieldSegmentation create(String fieldName, List<Double> thresholds, ElasticSearchQuery query) {
-    return new DoubleFieldSegmentation(fieldName, thresholds, query);
+  @Override
+  public ElasticSearchQuery getQuery(int i) {
+    if (getSegmentationByShards() && this.getQuery().getShards().size() > 1) {
+      return getQuery().withShards(Arrays.asList(getQuery().getShards().get(i / (thresholds.size() - 1))));
+    }
+
+    return getQuery();
+  }
+
+  public static DoubleFieldSegmentation create(String fieldName, List<Double> thresholds, ElasticSearchQuery query, Boolean segmentationByShards) {
+    return new DoubleFieldSegmentation(fieldName, thresholds, query, segmentationByShards);
   }
 }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/EmptySegmentation.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/EmptySegmentation.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 public final class EmptySegmentation extends SegmentationQueryTrait implements QuerySegmentation {
 
   private EmptySegmentation(ElasticSearchQuery query) {
-    super(query);
+    super(query, false);
   }
 
   @Override
@@ -23,6 +23,11 @@ public final class EmptySegmentation extends SegmentationQueryTrait implements Q
   @Override
   public Optional<BoundedSegment> getThreshold(int i) {
     return Optional.empty();
+  }
+
+  @Override
+  public ElasticSearchQuery getQuery(int i) {
+    return this.getQuery();
   }
 
   public static EmptySegmentation createEmptySegmentation(ElasticSearchQuery query) {

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/OnlyShardSegmentation.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/OnlyShardSegmentation.java
@@ -1,0 +1,48 @@
+package pl.allegro.tech.search.elasticsearch.tools.reindex.query;
+
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Created by Roman on 12/14/2015.
+ */
+public class OnlyShardSegmentation extends SegmentationQueryTrait implements QuerySegmentation {
+
+    private OnlyShardSegmentation(ElasticSearchQuery query) {
+        super(query, true);
+    }
+
+    @Override
+    public Optional<String> getFieldName() {
+        return Optional.empty();
+    }
+
+    @Override
+    public int getSegmentsCount() {
+        if (this.getQuery().getShards().size() > 1) {
+            return this.getQuery().getShards().size();
+        }
+
+        return 1;
+    }
+
+    @Override
+    public Optional<BoundedSegment> getThreshold(int i) {
+        return Optional.empty();
+    }
+
+    @Override
+    public ElasticSearchQuery getQuery(int i) {
+        if (this.getQuery().getShards().size() > 1) {
+            return this.getQuery().withShards(Arrays.asList(this.getQuery().getShards().get(i)));
+        }
+
+        return this.getQuery();
+    }
+
+    public static OnlyShardSegmentation createOnlyShardsSegmentation(ElasticSearchQuery query) {
+        return new OnlyShardSegmentation(query);
+    }
+}

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/QuerySegmentation.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/QuerySegmentation.java
@@ -12,5 +12,5 @@ public interface QuerySegmentation {
 
   Optional<BoundedSegment> getThreshold(int i);
 
-  ElasticSearchQuery getQuery();
+  ElasticSearchQuery getQuery(int i);
 }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/QuerySegmentationFactory.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/QuerySegmentationFactory.java
@@ -12,23 +12,34 @@ public final class QuerySegmentationFactory {
 
   public static QuerySegmentation create(ReindexCommand command) {
     ElasticSearchQuery query = buildQuery(command);
+
+    if (command.getSegmentationByShards() && query.getShards().isEmpty()) {
+      throw new BadSegmentationDefinitionException("Bad segmentation creation params");
+    }
+
     if (command.getSegmentationField() == null) {
+      if (command.getSegmentationByShards()) {
+        return OnlyShardSegmentation.createOnlyShardsSegmentation(query);
+      }
       return EmptySegmentation.createEmptySegmentation(query);
     }
+
     if (CollectionUtils.isNotEmpty(command.getSegmentationThresholds())) {
-      return DoubleFieldSegmentation.create(command.getSegmentationField(), command.getSegmentationThresholds(), query);
+      return DoubleFieldSegmentation.create(command.getSegmentationField(), command.getSegmentationThresholds(), query, command.getSegmentationByShards());
     }
+
     if (CollectionUtils.isNotEmpty(command.getSegmentationPrefixes())) {
-      return StringPrefixSegmentation.create(command.getSegmentationField(), command.getSegmentationPrefixes(), query);
+      return StringPrefixSegmentation.create(command.getSegmentationField(), command.getSegmentationPrefixes(), query, command.getSegmentationByShards());
     }
     throw new BadSegmentationDefinitionException("Bad segmentation creation params");
   }
 
   private static ElasticSearchQuery buildQuery(ReindexCommand command) {
     return ElasticSearchQueryBuilder.builder()
-        .setQuery(command.getQuery())
-        .setSortByField(command.getSort())
-        .setSortOrder(command.getSortOrder())
-        .build();
+            .setQuery(command.getQuery())
+            .setSortByField(command.getSort())
+            .setSortOrder(command.getSortOrder())
+            .setShards(command.getShards())
+            .build();
   }
 }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/SegmentationQueryTrait.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/SegmentationQueryTrait.java
@@ -1,17 +1,23 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.query;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
 
 public class SegmentationQueryTrait {
 
   private final ElasticSearchQuery query;
+  private final Boolean segmentationByShards;
 
-  public SegmentationQueryTrait(ElasticSearchQuery query) {
+  public SegmentationQueryTrait(ElasticSearchQuery query, Boolean segmentationByShards) {
     this.query = query;
+    this.segmentationByShards = segmentationByShards;
   }
 
   public ElasticSearchQuery getQuery() {
     return query;
   }
 
+  public Boolean getSegmentationByShards() {
+    return this.segmentationByShards;
+  }
 }

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/StringPrefixSegmentation.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/StringPrefixSegmentation.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.search.elasticsearch.tools.reindex.query;
 
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -13,11 +14,11 @@ public class StringPrefixSegmentation extends SegmentationQueryTrait implements 
 
   private final List<PrefixSegment> prefixSegmentsList;
 
-  public StringPrefixSegmentation(String fieldName, List<String> prefixesList, ElasticSearchQuery query) {
-    super(query);
+  public StringPrefixSegmentation(String fieldName, List<String> prefixesList, ElasticSearchQuery query, Boolean segmentationByShards) {
+    super(query, segmentationByShards);
     this.fieldName = fieldName;
     this.prefixSegmentsList = Collections.unmodifiableList(
-        prefixesList.stream().map(PrefixSegment::new).collect(Collectors.toList()));
+            prefixesList.stream().map(PrefixSegment::new).collect(Collectors.toList()));
   }
 
   @Override
@@ -27,15 +28,32 @@ public class StringPrefixSegmentation extends SegmentationQueryTrait implements 
 
   @Override
   public int getSegmentsCount() {
+    if (this.getSegmentationByShards() && this.getQuery().getShards().size() > 1) {
+      return prefixSegmentsList.size() * this.getQuery().getShards().size();
+    }
     return prefixSegmentsList.size();
   }
 
   @Override
   public Optional<BoundedSegment> getThreshold(int i) {
-    return Optional.of(prefixSegmentsList.get(i));
+    int thresholdIndex = i;
+    if (getSegmentationByShards() && this.getQuery().getShards().size() > 1) {
+      thresholdIndex = i % prefixSegmentsList.size();
+    }
+
+    return Optional.of(prefixSegmentsList.get(thresholdIndex));
   }
 
-  public static QuerySegmentation create(String fieldName, List<String> segmentationPrefixes, ElasticSearchQuery query) {
-    return new StringPrefixSegmentation(fieldName, segmentationPrefixes, query);
+  @Override
+  public ElasticSearchQuery getQuery(int i) {
+    if (getSegmentationByShards() && this.getQuery().getShards().size() > 1) {
+      return getQuery().withShards(Arrays.asList(getQuery().getShards().get(i / prefixSegmentsList.size())));
+    }
+
+    return getQuery();
+  }
+
+  public static StringPrefixSegmentation create(String fieldName, List<String> segmentationPrefixes, ElasticSearchQuery query, Boolean segmentationByShards) {
+    return new StringPrefixSegmentation(fieldName, segmentationPrefixes, query, segmentationByShards);
   }
 }

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/embeded/EmbeddedElasticsearchCluster.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/embeded/EmbeddedElasticsearchCluster.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.search.elasticsearch.tools.reindex.embeded;
 
 import static org.elasticsearch.node.NodeBuilder.nodeBuilder;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -27,12 +28,12 @@ public final class EmbeddedElasticsearchCluster {
 
   private EmbeddedElasticsearchCluster(String clusterName, int apiPort) {
     NodeBuilder nodeBuilder = nodeBuilder()
-        .clusterName(clusterName)
-        .data(true);
+            .clusterName(clusterName)
+            .data(true);
     ImmutableSettings.Builder settings = nodeBuilder.settings()
-        .put("http.port", ELS_PORT)
-        .put("index.store.type", "memory")
-        .put("transport.tcp.port", apiPort);
+            .put("http.port", ELS_PORT)
+            .put("index.store.type", "memory")
+            .put("transport.tcp.port", apiPort);
 
     dataNode = nodeBuilder.settings(settings).node();
     dataNode.client().admin().cluster().prepareHealth().setWaitForGreenStatus().get();
@@ -83,15 +84,15 @@ public final class EmbeddedElasticsearchCluster {
 
   public ElasticDataPointer createDataPointer(String indexName) {
     return ElasticDataPointerBuilder.builder()
-        .setAddress("http://127.0.0.1:" + ELS_TCP_PORT + "/" + indexName + "/" + ReindexInvokerTest.DATA_TYPE)
-        .setClusterName(CLUSTER_NAME)
-        .build();
+            .setAddress("http://127.0.0.1:" + ELS_TCP_PORT + "/" + indexName + "/" + ReindexInvokerTest.DATA_TYPE)
+            .setClusterName(CLUSTER_NAME)
+            .build();
   }
 
   public void indexWithSampleData(String sourceIndex, String type, Stream<IndexDocument> indexDocumentStream) {
     recreateIndex(sourceIndex);
     indexDocumentStream.forEach(
-        indexDocument -> indexDocument(sourceIndex, type, indexDocument)
+            indexDocument -> indexDocument(sourceIndex, type, indexDocument)
     );
     refreshIndex();
   }
@@ -102,9 +103,9 @@ public final class EmbeddedElasticsearchCluster {
 
   public void createIndex(String index, String type, XContentBuilder mappingDef) {
     dataNode.client().admin().indices()
-        .prepareCreate(index)
-        .addMapping(type, mappingDef)
-        .get();
+            .prepareCreate(index)
+            .addMapping(type, mappingDef)
+            .get();
   }
 
   public ElasticSearchQuery createInitialQuery(String query) {
@@ -113,5 +114,13 @@ public final class EmbeddedElasticsearchCluster {
 
   public ElasticSearchQuery createInitialQuery(String query, String orderByField) {
     return ElasticSearchQueryBuilder.builder().setQuery(query).setSortByField(orderByField).build();
+  }
+
+  public ElasticSearchQuery createInitialQuery(String query, List<Integer> shards) {
+    return ElasticSearchQueryBuilder.builder().setQuery(query).setShards(shards).build();
+  }
+
+  public ElasticSearchQuery createInitialQuery(String query, String orderByField, List<Integer> shards) {
+    return ElasticSearchQueryBuilder.builder().setQuery(query).setSortByField(orderByField).setShards(shards).build();
   }
 }

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/DoubleFieldSegmentationTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/DoubleFieldSegmentationTest.java
@@ -14,7 +14,7 @@ public class DoubleFieldSegmentationTest {
   @Test
   public void checkSegmentationFieldName() throws Exception {
     //when
-    DoubleFieldSegmentation segmentation = DoubleFieldSegmentation.create("name", Lists.newArrayList(0.0, 1.0), null);
+    DoubleFieldSegmentation segmentation = DoubleFieldSegmentation.create("name", Lists.newArrayList(0.0, 1.0), null, false);
 
     //then
     assertEquals("name", segmentation.getFieldName().get());
@@ -26,7 +26,7 @@ public class DoubleFieldSegmentationTest {
     ElasticSearchQuery query = ElasticSearchQueryBuilder.builder().build();
 
     //when
-    DoubleFieldSegmentation segmentation = DoubleFieldSegmentation.create("name", Lists.newArrayList(0.0, 1.0), query);
+    DoubleFieldSegmentation segmentation = DoubleFieldSegmentation.create("name", Lists.newArrayList(0.0, 1.0), query, false);
 
     //then
     assertEquals(query, segmentation.getQuery());
@@ -35,28 +35,28 @@ public class DoubleFieldSegmentationTest {
   @Test
   public void checkSegmentationOneThreshold() throws Exception {
     //when
-    DoubleFieldSegmentation segmentation = DoubleFieldSegmentation.create("name", Lists.newArrayList(0.0, 1.0), null);
+    DoubleFieldSegmentation segmentation = DoubleFieldSegmentation.create("name", Lists.newArrayList(0.0, 1.0), null, false);
 
     //then
     assertEquals(1, segmentation.getSegmentsCount());
     assertThat((RangeSegment) segmentation.getThreshold(0).get())
-        .hasLowerOpenBound(0.0)
-        .hasUpperBound(1.0);
+            .hasLowerOpenBound(0.0)
+            .hasUpperBound(1.0);
   }
 
   @Test
   public void checkSegmentationDoubleThreshold() throws Exception {
     //when
-    DoubleFieldSegmentation segmentation = DoubleFieldSegmentation.create("name", Lists.newArrayList(0.0, 1.0, 2.0), null);
+    DoubleFieldSegmentation segmentation = DoubleFieldSegmentation.create("name", Lists.newArrayList(0.0, 1.0, 2.0), null, false);
 
     //then
     assertEquals(2, segmentation.getSegmentsCount());
     assertThat((RangeSegment) segmentation.getThreshold(0).get())
-        .hasLowerOpenBound(0.0)
-        .hasUpperBound(1.0);
+            .hasLowerOpenBound(0.0)
+            .hasUpperBound(1.0);
     assertThat((RangeSegment) segmentation.getThreshold(1).get())
-        .hasLowerOpenBound(1.0)
-        .hasUpperBound(2.0);
+            .hasLowerOpenBound(1.0)
+            .hasUpperBound(2.0);
   }
 
 

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/QuerySegmentationFactoryTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/QuerySegmentationFactoryTest.java
@@ -1,11 +1,14 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.query;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.command.ReindexCommand;
+
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -14,6 +17,7 @@ import static pl.allegro.tech.search.elasticsearch.tools.reindex.query.PrefixSeg
 import static pl.allegro.tech.search.elasticsearch.tools.reindex.query.QuerySegmentationAssert.assertThat;
 import static pl.allegro.tech.search.elasticsearch.tools.reindex.query.RangeSegmentAssert.*;
 
+@SuppressWarnings("Duplicates")
 @RunWith(JUnitParamsRunner.class)
 public class QuerySegmentationFactoryTest {
 
@@ -40,12 +44,102 @@ public class QuerySegmentationFactoryTest {
     QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
     //then
     assertThat(querySegmentation)
-        .isInstanceOf(DoubleFieldSegmentation.class)
-        .hasFileName(fieldName)
-        .hasSegmentsCount(1);
+            .isInstanceOf(DoubleFieldSegmentation.class)
+            .hasFileName(fieldName)
+            .hasSegmentsCount(1);
     RangeSegmentAssert.assertThat((RangeSegment) (querySegmentation.getThreshold(0).get()))
-        .hasLowerOpenBound(lowerBound)
-        .hasUpperBound(upperBound);
+            .hasLowerOpenBound(lowerBound)
+            .hasUpperBound(upperBound);
+  }
+
+  @Test
+  @Parameters({ "1.0, 2.0" })
+  public void shouldCreateDoubleFieldSegmentationWithSegmentationByShards(double lowerBound, double upperBound) throws Exception {
+    //given
+    ReindexCommand command = mock(ReindexCommand.class);
+    String fieldName = "fieldName";
+    when(command.getSegmentationField()).thenReturn(fieldName);
+    when(command.getSegmentationThresholds()).thenReturn(Lists.newArrayList(lowerBound, upperBound));
+    when(command.getSegmentationByShards()).thenReturn(true);
+    when(command.getShards()).thenReturn(Arrays.asList(0, 1, 2, 3, 4));
+    //when
+    QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
+    //then
+    assertThat(querySegmentation)
+            .isInstanceOf(DoubleFieldSegmentation.class)
+            .hasFileName(fieldName)
+            .hasSegmentsCount(5);
+    for(int i = 0 ; i < 5; i++) {
+      RangeSegmentAssert.assertThat((RangeSegment) (querySegmentation.getThreshold(i).get()))
+              .hasLowerOpenBound(lowerBound)
+              .hasUpperBound(upperBound);
+    }
+  }
+
+  @Test
+  @Parameters({ "1.0, 2.0" })
+  public void shouldCreateDoubleFieldSegmentationWithSegmentationByShardsWithSingleShard(double lowerBound, double upperBound) throws Exception {
+    //given
+    ReindexCommand command = mock(ReindexCommand.class);
+    String fieldName = "fieldName";
+    when(command.getSegmentationField()).thenReturn(fieldName);
+    when(command.getSegmentationThresholds()).thenReturn(Lists.newArrayList(lowerBound, upperBound));
+    when(command.getSegmentationByShards()).thenReturn(true);
+    when(command.getShards()).thenReturn(Arrays.asList(0));
+    //when
+    QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
+    //then
+    assertThat(querySegmentation)
+            .isInstanceOf(DoubleFieldSegmentation.class)
+            .hasFileName(fieldName)
+            .hasSegmentsCount(1);
+    RangeSegmentAssert.assertThat((RangeSegment) (querySegmentation.getThreshold(0).get()))
+            .hasLowerOpenBound(lowerBound)
+            .hasUpperBound(upperBound);
+  }
+
+  @Test
+  @Parameters({ "1.0, 2.0" })
+  public void shouldCreateDoubleFieldSegmentationWithSingleShard(double lowerBound, double upperBound) throws Exception {
+    //given
+    ReindexCommand command = mock(ReindexCommand.class);
+    String fieldName = "fieldName";
+    when(command.getSegmentationField()).thenReturn(fieldName);
+    when(command.getSegmentationThresholds()).thenReturn(Lists.newArrayList(lowerBound, upperBound));
+    when(command.getSegmentationByShards()).thenReturn(false);
+    when(command.getShards()).thenReturn(Arrays.asList(0));
+    //when
+    QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
+    //then
+    assertThat(querySegmentation)
+            .isInstanceOf(DoubleFieldSegmentation.class)
+            .hasFileName(fieldName)
+            .hasSegmentsCount(1);
+    RangeSegmentAssert.assertThat((RangeSegment) (querySegmentation.getThreshold(0).get()))
+            .hasLowerOpenBound(lowerBound)
+            .hasUpperBound(upperBound);
+  }
+
+  @Test
+  @Parameters({ "1.0, 2.0" })
+  public void shouldCreateDoubleFieldSegmentationWithMultipleShards(double lowerBound, double upperBound) throws Exception {
+    //given
+    ReindexCommand command = mock(ReindexCommand.class);
+    String fieldName = "fieldName";
+    when(command.getSegmentationField()).thenReturn(fieldName);
+    when(command.getSegmentationThresholds()).thenReturn(Lists.newArrayList(lowerBound, upperBound));
+    when(command.getSegmentationByShards()).thenReturn(false);
+    when(command.getShards()).thenReturn(Arrays.asList(0, 1, 2, 3, 4));
+    //when
+    QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
+    //then
+    assertThat(querySegmentation)
+            .isInstanceOf(DoubleFieldSegmentation.class)
+            .hasFileName(fieldName)
+            .hasSegmentsCount(1);
+    RangeSegmentAssert.assertThat((RangeSegment) (querySegmentation.getThreshold(0).get()))
+            .hasLowerOpenBound(lowerBound)
+            .hasUpperBound(upperBound);
   }
 
   @Test
@@ -60,14 +154,138 @@ public class QuerySegmentationFactoryTest {
     QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
     //then
     assertThat(querySegmentation)
-        .isInstanceOf(StringPrefixSegmentation.class)
-        .hasFileName(fieldName)
-        .hasSegmentsCount(2);
+            .isInstanceOf(StringPrefixSegmentation.class)
+            .hasFileName(fieldName)
+            .hasSegmentsCount(2);
     assertThat((PrefixSegment) querySegmentation.getThreshold(0).get())
-        .hasPrefix(firstPrefix);
+            .hasPrefix(firstPrefix);
     assertThat((PrefixSegment) querySegmentation.getThreshold(1).get())
-        .hasPrefix(secondPrefix);
+            .hasPrefix(secondPrefix);
   }
+
+  @Test
+  @Parameters({ "1, 2" })
+  public void shouldCreateStringPrefixFieldSegmentationWithSegmentationByShards(String firstPrefix, String secondPrefix) throws Exception {
+    //given
+    ReindexCommand command = mock(ReindexCommand.class);
+    String fieldName = "fieldName";
+    when(command.getSegmentationField()).thenReturn(fieldName);
+    when(command.getSegmentationPrefixes()).thenReturn(Lists.newArrayList(firstPrefix, secondPrefix));
+    when(command.getSegmentationByShards()).thenReturn(true);
+    when(command.getShards()).thenReturn(Arrays.asList(0, 1, 2, 3, 4));
+    //when
+    QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
+    //then
+    assertThat(querySegmentation)
+            .isInstanceOf(StringPrefixSegmentation.class)
+            .hasFileName(fieldName)
+            .hasSegmentsCount(10);
+    for(int i = 0; i < 5; i++) {
+      assertThat((PrefixSegment) querySegmentation.getThreshold(i * 2).get())
+              .hasPrefix(firstPrefix);
+      assertThat((PrefixSegment) querySegmentation.getThreshold(i * 2 + 1).get())
+              .hasPrefix(secondPrefix);
+    }
+  }
+
+  @Test
+  @Parameters({ "1, 2" })
+  public void shouldCreateStringPrefixFieldSegmentationWithSegmentationByShardsWithSingleShard(String firstPrefix, String secondPrefix) throws Exception {
+    //given
+    ReindexCommand command = mock(ReindexCommand.class);
+    String fieldName = "fieldName";
+    when(command.getSegmentationField()).thenReturn(fieldName);
+    when(command.getSegmentationPrefixes()).thenReturn(Lists.newArrayList(firstPrefix, secondPrefix));
+    when(command.getSegmentationByShards()).thenReturn(true);
+    when(command.getShards()).thenReturn(Arrays.asList(0));
+    //when
+    QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
+    //then
+    assertThat(querySegmentation)
+            .isInstanceOf(StringPrefixSegmentation.class)
+            .hasFileName(fieldName)
+            .hasSegmentsCount(2);
+    assertThat((PrefixSegment) querySegmentation.getThreshold(0).get())
+            .hasPrefix(firstPrefix);
+    assertThat((PrefixSegment) querySegmentation.getThreshold(1).get())
+            .hasPrefix(secondPrefix);
+  }
+
+  @SuppressWarnings("Duplicates")
+  @Test
+  @Parameters({ "1, 2" })
+  public void shouldCreateStringPrefixFieldSegmentationWithSingleShard(String firstPrefix, String secondPrefix) throws Exception {
+    //given
+    ReindexCommand command = mock(ReindexCommand.class);
+    String fieldName = "fieldName";
+    when(command.getSegmentationField()).thenReturn(fieldName);
+    when(command.getSegmentationPrefixes()).thenReturn(Lists.newArrayList(firstPrefix, secondPrefix));
+    when(command.getSegmentationByShards()).thenReturn(false);
+    when(command.getShards()).thenReturn(Arrays.asList(0));
+    //when
+    QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
+    //then
+    assertThat(querySegmentation)
+            .isInstanceOf(StringPrefixSegmentation.class)
+            .hasFileName(fieldName)
+            .hasSegmentsCount(2);
+    assertThat((PrefixSegment) querySegmentation.getThreshold(0).get())
+            .hasPrefix(firstPrefix);
+    assertThat((PrefixSegment) querySegmentation.getThreshold(1).get())
+            .hasPrefix(secondPrefix);
+  }
+
+  @Test
+  @Parameters({ "1, 2" })
+  public void shouldCreateStringPrefixFieldSegmentationWithMultipleShards(String firstPrefix, String secondPrefix) throws Exception {
+    //given
+    ReindexCommand command = mock(ReindexCommand.class);
+    String fieldName = "fieldName";
+    when(command.getSegmentationField()).thenReturn(fieldName);
+    when(command.getSegmentationPrefixes()).thenReturn(Lists.newArrayList(firstPrefix, secondPrefix));
+    when(command.getSegmentationByShards()).thenReturn(false);
+    when(command.getShards()).thenReturn(Arrays.asList(0, 1, 2, 3, 4));
+    //when
+    QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
+    //then
+    assertThat(querySegmentation)
+            .isInstanceOf(StringPrefixSegmentation.class)
+            .hasFileName(fieldName)
+            .hasSegmentsCount(2);
+    assertThat((PrefixSegment) querySegmentation.getThreshold(0).get())
+            .hasPrefix(firstPrefix);
+    assertThat((PrefixSegment) querySegmentation.getThreshold(1).get())
+            .hasPrefix(secondPrefix);
+  }
+
+  @Test
+  public void shouldCreateOnlyShardSegmentationWithMultipleShards() throws Exception {
+    //given
+    ReindexCommand command = mock(ReindexCommand.class);
+    when(command.getSegmentationByShards()).thenReturn(true);
+    when(command.getShards()).thenReturn(Arrays.asList(0, 1, 2, 3, 4));
+    //when
+    QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
+    //then
+    assertThat(querySegmentation)
+            .isInstanceOf(OnlyShardSegmentation.class)
+            .hasSegmentsCount(5);
+  }
+
+  @Test
+  public void shouldCreateOnlyShardSegmentationWithSingleShards() throws Exception {
+    //given
+    ReindexCommand command = mock(ReindexCommand.class);
+    when(command.getSegmentationByShards()).thenReturn(true);
+    when(command.getShards()).thenReturn(Arrays.asList(0));
+    //when
+    QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
+    //then
+    assertThat(querySegmentation)
+            .isInstanceOf(OnlyShardSegmentation.class)
+            .hasSegmentsCount(1);
+  }
+
 
   @Test(expected = BadSegmentationDefinitionException.class)
   public void shouldThrowExceptionWhenBadSegmentationDefinition() throws Exception {
@@ -81,5 +299,14 @@ public class QuerySegmentationFactoryTest {
     throw new RuntimeException("shouldn't create segmentation for fieldName " + querySegmentation.getFieldName());
   }
 
-
+  @Test(expected = BadSegmentationDefinitionException.class)
+  public void shouldThrowExceptionWhenBadSegmentationDefinitionWithoutShards() throws Exception {
+    //given
+    ReindexCommand command = mock(ReindexCommand.class);
+    when(command.getSegmentationByShards()).thenReturn(true);
+    //when
+    QuerySegmentation querySegmentation = QuerySegmentationFactory.create(command);
+    //then
+    throw new RuntimeException("shouldn't create segmentation without shards when specifying segmentationByShards");
+  }
 }

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/StringPrefixSegmentationTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/query/StringPrefixSegmentationTest.java
@@ -15,7 +15,7 @@ public class StringPrefixSegmentationTest {
     //given
     ElasticSearchQuery query = ElasticSearchQueryBuilder.builder().build();
     //when
-    QuerySegmentation segmentation = StringPrefixSegmentation.create("fieldName", Collections.emptyList(), query);
+    StringPrefixSegmentation segmentation = StringPrefixSegmentation.create("fieldName", Collections.emptyList(), query, false);
 
     //then
     assertEquals(query, segmentation.getQuery());


### PR DESCRIPTION
Segmentation by shards is applied on top of already existing segmentation instructions if present, or if not present, operates as a specialized segmentation.

e.g: -s http://localhost:9300/index1/type1 -t http://localhost:9300/index2/type2 -sc clusterName -tc clusterName -shards 0,1,2,3,4 -segmentationByShards
This will create 5 querying processors for each mentioned shard

-s http://localhost:9300/index1/type1 -t http://localhost:9300/index2/type2 -sc clusterName -tc clusterName -shards 0,1,2
This will create a single query processor that will query only shards 0, 1, 2.

-s http://localhost:9300/index1/type1 -t http://localhost:9300/index2/type2 -sc clusterName -tc clusterName -shards 0,1,2

-s http://localhost:9300/index1/type1 -t http://localhost:9300/index2/type2 -sc clusterName -tc clusterName -shards 0,1,2,3,4 -segmentationByShards -segmentationField rate.newCoolness -segmentationThresholds 0.0,0.5,0.59,0.6,0.7,0.9,1.0
This will create 30 querying processors (num threshold segments \* num shards). Every shards will be queries by 6 querying processor for each bounded segment
