### PR TITLE
Better compute "sizePerShards" for the scroll-based-query

### DIFF
--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/QueryComponent.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/QueryComponent.java
@@ -1,12 +1,18 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.process;
 
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.google.common.base.Strings;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
 import pl.allegro.tech.search.elasticsearch.tools.reindex.query.BoundedSegment;
@@ -15,9 +21,10 @@ import pl.allegro.tech.search.elasticsearch.tools.reindex.query.filter.BoundedFi
 import java.util.Optional;
 
 public class QueryComponent {
+  private static final Logger logger = LoggerFactory.getLogger(QueryComponent.class);
 
   public static final int SCROLL_TIME_LIMIT = 60000;
-  public static final int SCROLL_SHARD_LIMIT = 200;
+  public static final int SCROLL_SHARD_LIMIT = 5000;
   public static final int SCROLL_TIMEOUT = 600000;
 
   private Client client;
@@ -36,12 +43,28 @@ public class QueryComponent {
   }
 
   public SearchResponse prepareSearchScrollRequest() {
+    // find out how many indices and shards are affected by this query to not get huge result sets when there are very many indices affected by the name, e.g. when wildcards are used
+    // otherwise we regularly run into OOMs when a query goes against a large number of indices
+    // I did not find a better way to find out the number of Shards then to get a list of indices and for each index query the replicas/shards via the settings
+    GetSettingsResponse getSettingsResponse = client.admin().indices().getSettings(new GetSettingsRequest().indices(dataPointer.getIndexName())).actionGet();
+    int numShards = 0, numIndices = 0;
+    for(ObjectCursor<Settings> settings : getSettingsResponse.getIndexToSettings().values()) {
+      int replicas = settings.value.getAsInt("index.number_of_replicas", 0) + 1;
+      int shards = settings.value.getAsInt("index.number_of_shards", 0);
+
+      numShards += replicas*shards;
+      numIndices++;
+    }
+
+    int sizePerShard = (int)Math.ceil((double)SCROLL_SHARD_LIMIT/numShards);
+    logger.info("Found " + numIndices + " indices and " + numShards + " shards matching the index-pattern, thus setting the sizePerShard to " + sizePerShard);
+
     SearchRequestBuilder searchRequestBuilder = client.prepareSearch(dataPointer.getIndexName())
         .setTypes(dataPointer.getTypeName())
         .setSearchType(SearchType.SCAN)
         .addFields("_ttl", "_source")
         .setScroll(new TimeValue(SCROLL_TIME_LIMIT))
-        .setSize(SCROLL_SHARD_LIMIT);
+        .setSize(sizePerShard);
 
     if (!Strings.isNullOrEmpty(query.getQuery())) {
       searchRequestBuilder.setQuery(query.getQuery());

--- a/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/QueryComponent.java
+++ b/src/main/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/QueryComponent.java
@@ -45,14 +45,11 @@ public class QueryComponent {
   public SearchResponse prepareSearchScrollRequest() {
     // find out how many indices and shards are affected by this query to not get huge result sets when there are very many indices affected by the name, e.g. when wildcards are used
     // otherwise we regularly run into OOMs when a query goes against a large number of indices
-    // I did not find a better way to find out the number of Shards then to get a list of indices and for each index query the replicas/shards via the settings
+    // I did not find a better way to find out the number of shards than to query a list of indices and for each index query the number of shards via the settings
     GetSettingsResponse getSettingsResponse = client.admin().indices().getSettings(new GetSettingsRequest().indices(dataPointer.getIndexName())).actionGet();
     int numShards = 0, numIndices = 0;
     for(ObjectCursor<Settings> settings : getSettingsResponse.getIndexToSettings().values()) {
-      int replicas = settings.value.getAsInt("index.number_of_replicas", 0) + 1;
-      int shards = settings.value.getAsInt("index.number_of_shards", 0);
-
-      numShards += replicas*shards;
+      numShards += settings.value.getAsInt("index.number_of_shards", 0);
       numIndices++;
     }
 

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/QueryComponentTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/QueryComponentTest.java
@@ -1,0 +1,186 @@
+package pl.allegro.tech.search.elasticsearch.tools.reindex.process;
+
+import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.unit.TimeValue;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticDataPointer;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchClientFactory;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.connection.ElasticSearchQuery;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.embeded.EmbeddedElasticsearchCluster;
+import pl.allegro.tech.search.elasticsearch.tools.reindex.embeded.IndexDocument;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.*;
+
+public class QueryComponentTest {
+  private static final String SOURCE_INDEX = "sourceindex";
+  private static final String TARGET_INDEX = "targetindex";
+  public static final String DATA_TYPE = "type";
+
+  private static EmbeddedElasticsearchCluster embeddedElasticsearchCluster;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    embeddedElasticsearchCluster = EmbeddedElasticsearchCluster.createDataNode();
+  }
+
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    embeddedElasticsearchCluster.close();
+  }
+
+  @Before
+  public void clearTargetIndex() {
+    embeddedElasticsearchCluster.deleteIndex(SOURCE_INDEX);
+    embeddedElasticsearchCluster.deleteIndex(TARGET_INDEX);
+  }
+
+  @Test
+  public void testQueryNoData() {
+    // given
+    embeddedElasticsearchCluster.recreateIndex(SOURCE_INDEX);
+    ElasticDataPointer sourceDataPointer = embeddedElasticsearchCluster.createDataPointer(SOURCE_INDEX);
+    Client sourceClient = ElasticSearchClientFactory.createClient(sourceDataPointer);
+    ElasticSearchQuery elasticSearchQuery = embeddedElasticsearchCluster.createInitialQuery("");
+
+    // when
+    QueryComponent component = QueryComponentBuilder.builder()
+            .setClient(sourceClient)
+            .setDataPointer(sourceDataPointer)
+            .setQuery(elasticSearchQuery)
+            .createQueryComponent();
+    SearchResponse searchResponse = component.prepareSearchScrollRequest();
+
+    // then
+    assertEquals("No results overall",
+            0L, searchResponse.getHits().getTotalHits());
+    assertEquals("Initially zero documents are loaded",
+            0L, searchResponse.getHits().getHits().length);
+    assertEquals("Initially zero documents are loaded",
+            0L, component.getResponseSize(searchResponse));
+    assertFalse("Some documents are found",
+            component.searchResultsNotEmpty(searchResponse));
+
+    // when
+    searchResponse = component.getNextScrolledSearchResults(searchResponse.getScrollId());
+
+    // then
+    assertEquals("No results overall",
+            0L, searchResponse.getHits().getTotalHits());
+    assertEquals("Initially zero documents are loaded",
+            0L, searchResponse.getHits().getHits().length);
+    assertEquals("Initially zero documents are loaded",
+            0L, component.getResponseSize(searchResponse));
+    assertFalse("Some documents are found",
+            component.searchResultsNotEmpty(searchResponse));
+  }
+
+  @Test
+  public void testQueryWithData() {
+    // given
+    indexWithSampleData(7000);
+    ElasticDataPointer sourceDataPointer = embeddedElasticsearchCluster.createDataPointer(SOURCE_INDEX);
+    Client sourceClient = ElasticSearchClientFactory.createClient(sourceDataPointer);
+    ElasticSearchQuery elasticSearchQuery = embeddedElasticsearchCluster.createInitialQuery("");
+
+    GetSettingsResponse indexSettings = sourceClient.admin().indices().getSettings(new GetSettingsRequest().indices(SOURCE_INDEX)).actionGet();
+    assertEquals("We should have an index with 5 shards now",
+            "5", indexSettings.getIndexToSettings().get(SOURCE_INDEX).get("index.number_of_shards"));
+    assertEquals("We should have an index with one replica now",
+            "1", indexSettings.getIndexToSettings().get(SOURCE_INDEX).get("index.number_of_replicas"));
+
+    // when
+    QueryComponent component = QueryComponentBuilder.builder()
+            .setClient(sourceClient)
+            .setDataPointer(sourceDataPointer)
+            .setQuery(elasticSearchQuery)
+            .createQueryComponent();
+    SearchResponse searchResponse = component.prepareSearchScrollRequest();
+
+    // then
+    assertEquals("Overall there should be 7000 hits",
+            7000L, searchResponse.getHits().getTotalHits());
+    assertEquals("Initially zero documents are loaded",
+            0L, searchResponse.getHits().getHits().length);
+    assertEquals("Initially zero documents are loaded",
+            0L, component.getResponseSize(searchResponse));
+    assertTrue("Some documents are found",
+            component.searchResultsNotEmpty(searchResponse));
+
+    // when
+    searchResponse = component.getNextScrolledSearchResults(searchResponse.getScrollId());
+
+    // then
+    assertEquals("Overall there should be 7000 hits",
+            7000L, searchResponse.getHits().getTotalHits());
+    assertEquals("QueryComponent tries to compute the hits to be 5000 on evenly distributed documents, never more!",
+            5000L, searchResponse.getHits().getHits().length);
+    assertEquals("QueryComponent tries to compute the hits to be 5000 on evenly distributed documents, never more!",
+            5000L, component.getResponseSize(searchResponse));
+    assertTrue("Some documents are found",
+            component.searchResultsNotEmpty(searchResponse));
+  }
+
+  // just a simple test to verify that replica-shards are not included in the calculation of results
+  // for the "size per shard" setting in scan/scroll-queries
+  @Test
+  public void testElasticsearchReplicaHandlingInScrolls() {
+    // given
+    indexWithSampleData(200);
+    ElasticDataPointer sourceDataPointer = embeddedElasticsearchCluster.createDataPointer(SOURCE_INDEX);
+    Client sourceClient = ElasticSearchClientFactory.createClient(sourceDataPointer);
+
+    GetSettingsResponse indexSettings = sourceClient.admin().indices().getSettings(new GetSettingsRequest().indices(SOURCE_INDEX)).actionGet();
+    assertEquals("We should have an index with 5 shards now",
+            "5", indexSettings.getIndexToSettings().get(SOURCE_INDEX).get("index.number_of_shards"));
+    assertEquals("We should have an index with one replica now",
+            "1", indexSettings.getIndexToSettings().get(SOURCE_INDEX).get("index.number_of_replicas"));
+
+    // when
+    SearchRequestBuilder searchRequestBuilder = sourceClient.prepareSearch(sourceDataPointer.getIndexName())
+            .setTypes(DATA_TYPE)
+            .setSearchType(SearchType.SCAN)
+            .addFields("_ttl", "_source")
+            .setScroll(new TimeValue(QueryComponent.SCROLL_TIME_LIMIT))
+            .setSize(10);
+    assertNotNull(searchRequestBuilder);
+
+    // then
+    SearchResponse searchResponse = searchRequestBuilder.execute().actionGet();
+    assertEquals("Overall there should be 200 hits",
+            200L, searchResponse.getHits().getTotalHits());
+    assertEquals("Initially zero documents are loaded",
+            0L, searchResponse.getHits().getHits().length);
+
+    // when
+    searchResponse = sourceClient.prepareSearchScroll(searchResponse.getScrollId())
+            .setScroll(new TimeValue(QueryComponent.SCROLL_TIMEOUT))
+            .get();
+
+    // then
+    assertEquals(200L, searchResponse.getHits().getTotalHits());
+    assertEquals(50L, searchResponse.getHits().getHits().length);
+  }
+
+
+  private void indexWithSampleData(final int numberOfDocuments) {
+    Stream<IndexDocument> streamToBeIndexed = IntStream
+            .range(1, numberOfDocuments+1)
+            .mapToObj(
+                    i -> new IndexDocument(Integer.toString(i), ImmutableMap.of("fieldName", i))
+            );
+    embeddedElasticsearchCluster.indexWithSampleData(SOURCE_INDEX, DATA_TYPE, streamToBeIndexed);
+  }
+}


### PR DESCRIPTION
The "size" on a scroll query is not the actual max number of results for each paged-request, but rather the size _per Shard_ for each paged-request. If you have a lot of shards (e.g. when you use wildcards in index-names to query data from many indices in combination with time-based indices-names), you likely end up requesting a huge number of results and will run into out of memory issues on the client.

This PR changes this logic by analyzing the number of shards that are affected by the query and limiting the overall scroll-size to be up to 5000 max instead of the 200-per-shard limit applied currently.
