### PR TITLE
Allow to derive the target-index from the document

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ With query option:
  
  In this example index querying will be filtered with query and reindex will take place ordered by sort field and sortOrder 
 
+With target index name pattern
+
+Use the actual source-index of the document (useful when you use wildcards for the source-index):
+`./run.sh -s http://host:9300/*/type -t http://host1:9300/${_index}/type1  -sc cluster_name -tc cluster_name1`
+
+Use a field from the document:
+`./run.sh -s http://host:9300/index/type -t http://host1:9300/${customer}/type1  -sc cluster_name -tc cluster_name1`
+
+Use a time-field from the document and apply a format:
+`./run.sh -s http://host:9300/index/type -t http://host1:9300/${startTime:yyyy-MM-dd}/type1  -sc cluster_name -tc cluster_name1`
+
 Options:
 
     -s, source

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/IndexingComponentTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/IndexingComponentTest.java
@@ -48,8 +48,8 @@ public class IndexingComponentTest {
     assertEquals("doc-2015-05-23doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}doc", Collections.singletonMap("startTime", Long.toString(may2015)), null));
     assertEquals("doc-2015-05-23 11:23:00doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd HH:mm:ss}doc", Collections.singletonMap("startTime", Long.toString(may2015)), null));
 
-    map.put("startTime", Long.toString(DATE_FORMAT.parse("2015-05-23 23:12").getTime()));
-    map.put("endTime", "1456265552000");
+    map.put("startTime", Long.toString(DATE_FORMAT.parse("2015-05-23 21:12").getTime()));
+    map.put("endTime", Long.toString(DATE_FORMAT.parse("2015-05-24 23:12").getTime()));
     assertEquals("doc-2015-05-2323:12doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}${endTime:HH:mm}doc", map, null));
   }
 }

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/IndexingComponentTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/IndexingComponentTest.java
@@ -47,7 +47,8 @@ public class IndexingComponentTest {
     assertEquals("doc-1970-01-01doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}doc", Collections.singletonMap("startTime", Long.toString(jan1970)), null));
     assertEquals("doc-2015-05-23doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}doc", Collections.singletonMap("startTime", Long.toString(may2015)), null));
     assertEquals("doc-2015-05-23 11:23:00doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd HH:mm:ss}doc", Collections.singletonMap("startTime", Long.toString(may2015)), null));
-    map.put("startTime", "1432332000000");
+
+    map.put("startTime", Long.toString(DATE_FORMAT.parse("2015-05-23 23:12").getTime()));
     map.put("endTime", "1456265552000");
     assertEquals("doc-2015-05-2323:12doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}${endTime:HH:mm}doc", map, null));
   }

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/IndexingComponentTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/IndexingComponentTest.java
@@ -1,8 +1,8 @@
 package pl.allegro.tech.search.elasticsearch.tools.reindex.process;
 
-import org.elasticsearch.common.collect.MapBuilder;
 import org.junit.Test;
 
+import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -11,37 +11,44 @@ import static org.junit.Assert.*;
 
 public class IndexingComponentTest {
 
-    @Test
-    public void testComputeIndexName() throws Exception {
-        // no replacement and error cases
-        assertEquals("myindex", IndexingComponent.computeIndexName("myindex", null, null));
-        assertEquals("", IndexingComponent.computeIndexName("", null, null));
-        try {
-            IndexingComponent.computeIndexName("${value}", Collections.emptyMap(), null);
-            fail("Should throw NullPointerException with informative text");
-        } catch (NullPointerException e) {
-            assertTrue(!e.getMessage().isEmpty());
-        }
+  public static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm");
 
-        // simple replacement
-        assertEquals("123", IndexingComponent.computeIndexName("${value}", Collections.singletonMap("value", "123"), null));
-        assertEquals("doc-123", IndexingComponent.computeIndexName("doc-${value}", Collections.singletonMap("value", "123"), null));
-        assertEquals("doc-123doc", IndexingComponent.computeIndexName("doc-${value}doc", Collections.singletonMap("value", "123"), null));
-
-        // multiple replacements
-        Map<String, Object> map = new HashMap<>();
-        map.put("value", (Object)"123");
-        map.put("key", (Object)"key45");
-        assertEquals("doc-123dockey45", IndexingComponent.computeIndexName("doc-${value}doc${key}", map, null));
-
-        // source-index
-        assertEquals("doc-idx43doc", IndexingComponent.computeIndexName("doc-${_index}doc", null, "idx43"));
-
-        // date/time formatting
-        assertEquals("doc-1970-01-01doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}doc", Collections.singletonMap("startTime", "2387433"), null));
-        assertEquals("doc-2015-05-23doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}doc", Collections.singletonMap("startTime", "1432332000000"), null));
-        map.put("startTime", "1432332000000");
-        map.put("endTime", "1456265552000");
-        assertEquals("doc-2015-05-2323:12doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}${endTime:HH:mm}doc", map, null));
+  @Test
+  public void testComputeIndexName() throws Exception {
+    // no replacement and error cases
+    assertEquals("myindex", IndexingComponent.computeIndexName("myindex", null, null));
+    assertEquals("", IndexingComponent.computeIndexName("", null, null));
+    try {
+      IndexingComponent.computeIndexName("${value}", Collections.emptyMap(), null);
+      fail("Should throw NullPointerException with informative text");
+    } catch (NullPointerException e) {
+      assertTrue(!e.getMessage().isEmpty());
     }
+
+    // simple replacement
+    assertEquals("123", IndexingComponent.computeIndexName("${value}", Collections.singletonMap("value", "123"), null));
+    assertEquals("doc-123", IndexingComponent.computeIndexName("doc-${value}", Collections.singletonMap("value", "123"), null));
+    assertEquals("doc-123doc", IndexingComponent.computeIndexName("doc-${value}doc", Collections.singletonMap("value", "123"), null));
+
+    // multiple replacements
+    Map<String, Object> map = new HashMap<>();
+    map.put("value", (Object) "123");
+    map.put("key", (Object) "key45");
+    assertEquals("doc-123dockey45", IndexingComponent.computeIndexName("doc-${value}doc${key}", map, null));
+
+    // source-index
+    assertEquals("doc-idx43doc", IndexingComponent.computeIndexName("doc-${_index}doc", null, "idx43"));
+
+    // parse the date to avoid issues due to different timezones
+    long jan1970 = DATE_FORMAT.parse("1970-01-01 03:23").getTime();
+    long may2015 = DATE_FORMAT.parse("2015-05-23 11:23").getTime();
+
+    // date/time formatting
+    assertEquals("doc-1970-01-01doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}doc", Collections.singletonMap("startTime", Long.toString(jan1970)), null));
+    assertEquals("doc-2015-05-23doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}doc", Collections.singletonMap("startTime", Long.toString(may2015)), null));
+    assertEquals("doc-2015-05-23 11:23:00doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd HH:mm:ss}doc", Collections.singletonMap("startTime", Long.toString(may2015)), null));
+    map.put("startTime", "1432332000000");
+    map.put("endTime", "1456265552000");
+    assertEquals("doc-2015-05-2323:12doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}${endTime:HH:mm}doc", map, null));
+  }
 }

--- a/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/IndexingComponentTest.java
+++ b/src/test/java/pl/allegro/tech/search/elasticsearch/tools/reindex/process/IndexingComponentTest.java
@@ -1,0 +1,47 @@
+package pl.allegro.tech.search.elasticsearch.tools.reindex.process;
+
+import org.elasticsearch.common.collect.MapBuilder;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class IndexingComponentTest {
+
+    @Test
+    public void testComputeIndexName() throws Exception {
+        // no replacement and error cases
+        assertEquals("myindex", IndexingComponent.computeIndexName("myindex", null, null));
+        assertEquals("", IndexingComponent.computeIndexName("", null, null));
+        try {
+            IndexingComponent.computeIndexName("${value}", Collections.emptyMap(), null);
+            fail("Should throw NullPointerException with informative text");
+        } catch (NullPointerException e) {
+            assertTrue(!e.getMessage().isEmpty());
+        }
+
+        // simple replacement
+        assertEquals("123", IndexingComponent.computeIndexName("${value}", Collections.singletonMap("value", "123"), null));
+        assertEquals("doc-123", IndexingComponent.computeIndexName("doc-${value}", Collections.singletonMap("value", "123"), null));
+        assertEquals("doc-123doc", IndexingComponent.computeIndexName("doc-${value}doc", Collections.singletonMap("value", "123"), null));
+
+        // multiple replacements
+        Map<String, Object> map = new HashMap<>();
+        map.put("value", (Object)"123");
+        map.put("key", (Object)"key45");
+        assertEquals("doc-123dockey45", IndexingComponent.computeIndexName("doc-${value}doc${key}", map, null));
+
+        // source-index
+        assertEquals("doc-idx43doc", IndexingComponent.computeIndexName("doc-${_index}doc", null, "idx43"));
+
+        // date/time formatting
+        assertEquals("doc-1970-01-01doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}doc", Collections.singletonMap("startTime", "2387433"), null));
+        assertEquals("doc-2015-05-23doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}doc", Collections.singletonMap("startTime", "1432332000000"), null));
+        map.put("startTime", "1432332000000");
+        map.put("endTime", "1456265552000");
+        assertEquals("doc-2015-05-2323:12doc", IndexingComponent.computeIndexName("doc-${startTime:yyyy-MM-dd}${endTime:HH:mm}doc", map, null));
+    }
+}


### PR DESCRIPTION
Allow the target-index to be a pattern which is resolved for every document and this way can use either the source-index or values of fields from the current document for defining the resulting target-index. 

This is useful if you would like to split the index differently or use time-based indexing and would like to change the time-slots, but still want to reindex in-bulk across multiple indices.
